### PR TITLE
IGuiTextField.java: Defer to super method for setting focus.

### DIFF
--- a/src/main/java/com/projecturanus/betterp2p/client/gui/widget/IGuiTextField.java
+++ b/src/main/java/com/projecturanus/betterp2p/client/gui/widget/IGuiTextField.java
@@ -13,7 +13,7 @@ public class IGuiTextField extends MEGuiTextField {
     }
 
     public void setFocus(boolean focus, int position) {
-        this.field.setFocused(focus);
+        super.setFocused(focus);
         this.field.setCursorPosition(position);
     }
 
@@ -35,6 +35,6 @@ public class IGuiTextField extends MEGuiTextField {
     }
 
     public void setFocus(boolean focus) {
-        this.field.setFocused(focus);
+        super.setFocused(focus);
     }
 }


### PR DESCRIPTION
Previously, when renaming P2P connections the text field would accept one keyboard input and ignore whether the key is being held down.

Commit defers the "setFocus" method back to the super method (AE2's text field widget) for setting focus, which has some code to avoid this problem. Largest use case is when holding the backspace key to completely rename a connection.

Tested within dev environment only.