### PR TITLE
Remove duplicate P2P Tunnel entries

### DIFF
--- a/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
+++ b/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
@@ -44,13 +44,13 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     private var sortedInfo = infos.toList()
 
     private var selectedInfo: InfoWrapper?
-        get() = infos.getOrNull(selectedIndex)
+        get() = sortedInfo.find { it.index == selectedIndex }
         set(value) {
             selectedIndex = value?.index ?: -1
         }
 
     private val widgetDevices: List<WidgetP2PDevice>
-    private var infoOnScreen: List<InfoWrapper>
+//    private var infoOnScreen: List<InfoWrapper>
 
     private val descriptionLines: MutableList<String> = mutableListOf()
     private var mode = msg.memoryInfo.mode
@@ -58,9 +58,11 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     private val modeButton by lazy { GuiButton(0, guiLeft + 8, guiTop + 190, 256, 20, modeString) }
 
     init {
-        selectInfo(msg.memoryInfo.selectedIndex)
         sortInfo()
-        infoOnScreen = sortedInfo.take(5)
+        selectedIndex = mapSelected(msg.memoryInfo.selectedIndex)
+        sortInfo()
+//        infoOnScreen = sortedInfo.take(5)
+        selectInfo(selectedIndex)
 
         val list = mutableListOf<WidgetP2PDevice>()
         for (i in 0..3) {
@@ -93,28 +95,36 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     }
 
     private fun reGenInfoFromText() {
-        var tmpInfo = infos.filter {
-            it.frequency.toHexString().contains(searchBar.text.uppercase()) ||
-            it.frequency.toHexString().format4().contains(searchBar.text.uppercase()) ||
-            it.name.lowercase().contains(searchBar.text.lowercase())
-        }
-        if (searchBar.text.isEmpty())
-            tmpInfo = infos
-        sortedInfo = tmpInfo.sortedBy {
-            if (it.index == selectedIndex) {
-                -2 // Put the selected p2p in the front
-            } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency && !it.output) {
-                -3 // Put input in the beginning
-            } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency) {
-                -1 // Put same frequency in the front
-            } else {
-                it.frequency + Short.MAX_VALUE
+        if (searchBar.text.isEmpty()) {
+            sortInfo()
+        } else {
+            val tmp = mutableSetOf<String>()
+            val tmpInfo = infos.filter {
+                it.frequency.toHexString().contains(searchBar.text.uppercase()) ||
+                    it.frequency.toHexString().format4().contains(searchBar.text.uppercase()) ||
+                    it.name.lowercase().contains(searchBar.text.lowercase())
+            }
+            sortedInfo = tmpInfo.sortedBy {
+                if (it.index == selectedIndex) {
+                    -2 // Put the selected p2p in the front
+                } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency && !it.output) {
+                    -3 // Put input in the beginning
+                } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency) {
+                    -1 // Put same frequency in the front
+                } else {
+                    it.frequency + Short.MAX_VALUE
+                }
+            }.filter {
+                tmp.add(it.toString())
             }
         }
     }
 
     private fun sortInfo() {
-        sortedInfo = infos.sortedBy {
+        val tmp = mutableSetOf<String>()
+        sortedInfo = infos.filter {
+            tmp.add(it.toString())
+        }.sortedBy {
             if (it.index == selectedIndex) {
                 -2 // Put the selected p2p in the front
             } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency && !it.output) {
@@ -135,15 +145,14 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     }
 
     fun refreshInfo(infos: List<P2PInfo>,reGenInfo:Boolean=false) {
-        for (info in infos) {
-            val wrapper = InfoWrapper(info)
-            this.infos[info.index] = wrapper
-        }
+        infos.forEach { this.infos[it.index] = InfoWrapper(it) }
         checkInfo()
-        sortInfo()
-        refreshOverlay()
-        if(reGenInfo)
+        if(reGenInfo) {
             reGenInfoFromText()
+        } else {
+            sortInfo()
+        }
+        refreshOverlay()
     }
 
     private fun syncMemoryInfo() {
@@ -203,8 +212,19 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     private fun findInput(frequency: Long) =
         infos.find { it.frequency == frequency && !it.output }
 
+    /*
+     * Maps the index to one that exists in the filtered/sorted list.
+     */
+    private fun mapSelected(index: Int) : Int {
+        return if (index >= 0) {
+            sortedInfo.find {
+                it.toString() == infos[index].toString()
+            }?.index ?: -1
+        } else -1
+    }
+
     private fun selectInfo(index: Int) {
-        selectedIndex = index
+        selectedIndex = mapSelected(index)
         syncMemoryInfo()
         refreshOverlay()
     }
@@ -219,7 +239,7 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
             ClientCache.selectedFacing = selectedInfo?.facing
         }
         ClientCache.positions.clear()
-        ClientCache.positions.addAll(infos.filter { it.frequency == selectedInfo?.frequency && it != selectedInfo }.map { arrayListOf(it.posX, it.posY, it.posZ) to it.facing })
+        ClientCache.positions.addAll(sortedInfo.filter { it.frequency == selectedInfo?.frequency && it != selectedInfo }.map { arrayListOf(it.posX, it.posY, it.posZ) to it.facing })
     }
 
     private fun onSelectButtonClicked(info: InfoWrapper) {

--- a/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
+++ b/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
@@ -58,9 +58,18 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     private val modeButton by lazy { GuiButton(0, guiLeft + 8, guiTop + 190, 256, 20, modeString) }
 
     init {
-        sortInfo()
+        val tmp = mutableSetOf<String>()
+        sortedInfo = sortedInfo.filter { tmp.add(it.toString()) }
         selectedIndex = mapSelected(msg.memoryInfo.selectedIndex)
-        sortInfo()
+        sortedInfo.sortedBy { if (it.index == selectedIndex) {
+            -2 // Put the selected p2p in the front
+        } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency && !it.output) {
+            -3 // Put input in the beginning
+        } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency) {
+            -1 // Put same frequency in the front
+        } else {
+            it.frequency + Short.MAX_VALUE
+        } }
 //        infoOnScreen = sortedInfo.take(5)
         selectInfo(selectedIndex)
 
@@ -104,7 +113,9 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
                     it.frequency.toHexString().format4().contains(searchBar.text.uppercase()) ||
                     it.name.lowercase().contains(searchBar.text.lowercase())
             }
-            sortedInfo = tmpInfo.sortedBy {
+            sortedInfo = tmpInfo.filter {
+                tmp.add(it.toString())
+            }.sortedBy {
                 if (it.index == selectedIndex) {
                     -2 // Put the selected p2p in the front
                 } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency && !it.output) {
@@ -114,8 +125,6 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
                 } else {
                     it.frequency + Short.MAX_VALUE
                 }
-            }.filter {
-                tmp.add(it.toString())
             }
         }
     }
@@ -124,7 +133,8 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
         val tmp = mutableSetOf<String>()
         sortedInfo = infos.filter {
             tmp.add(it.toString())
-        }.sortedBy {
+        }
+        sortedInfo = sortedInfo.sortedBy {
             if (it.index == selectedIndex) {
                 -2 // Put the selected p2p in the front
             } else if (it.frequency != 0.toLong() && it.frequency == selectedInfo?.frequency && !it.output) {

--- a/src/main/java/com/projecturanus/betterp2p/client/gui/InfoWrapper.kt
+++ b/src/main/java/com/projecturanus/betterp2p/client/gui/InfoWrapper.kt
@@ -39,6 +39,10 @@ class InfoWrapper(info: P2PInfo) {
                 append(info.frequency.toHexString().format4())
         }
     }
+
+    override fun toString() : String {
+        return "${posX}_${posY}_${posZ}_${world}_${facing}"
+    }
 }
 
 fun Long.toHexString(): String {

--- a/src/main/java/com/projecturanus/betterp2p/network/C2SP2PTunnelInfo.kt
+++ b/src/main/java/com/projecturanus/betterp2p/network/C2SP2PTunnelInfo.kt
@@ -6,7 +6,6 @@ import io.netty.buffer.ByteBuf
 
 fun readP2PTunnelInfo(buf: ByteBuf): P2PTunnelInfo {
     return P2PTunnelInfo(buf.readInt(),buf.readInt(),buf.readInt(),buf.readInt(),buf.readInt(), buf.readBytes(buf.readInt()).toString(Charsets.UTF_8))
-
 }
 
 fun writeP2PTunnelInfo(buf: ByteBuf,info: P2PTunnelInfo) {

--- a/src/main/java/com/projecturanus/betterp2p/network/ClientRefreshInfoHandler.kt
+++ b/src/main/java/com/projecturanus/betterp2p/network/ClientRefreshInfoHandler.kt
@@ -13,7 +13,7 @@ class ClientRefreshInfoHandler : IMessageHandler<S2CRefreshInfo, IMessage?> {
     override fun onMessage(message: S2CRefreshInfo, ctx: MessageContext): IMessage? {
         val gui = Minecraft.getMinecraft().currentScreen
         if (gui is GuiAdvancedMemoryCard) {
-            gui.refreshInfo(message.infos)
+            gui.refreshInfo(message.infos, true)
         }
         return null
     }


### PR DESCRIPTION
Fixes
- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12533
- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12220

Description
- Removes duplicate entries from the P2P tunnel list by filtering the P2P tunnel list when showing it to the player.
- Entries now respect search terms after binding

Personally to me this feels more like a bandaid fix for the first bug. I don't understand AE2's P2P system very well, so for now I'm fixing it on the "frontend".

*Tested in dev only.*