### PR TITLE
Fix disappearing bind button when renaming search

### DIFF
--- a/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
+++ b/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
@@ -44,7 +44,7 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
     private var sortedInfo = infos.toList()
 
     private var selectedInfo: InfoWrapper?
-        get() = sortedInfo.find { it.index == selectedIndex }
+        get() = infos.find { it.index == selectedIndex }
         set(value) {
             selectedIndex = value?.index ?: -1
         }


### PR DESCRIPTION
See commit description. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12652

*Why this is a draft*
I'm getting really strange network bugs that I haven't been able to reproduce consistently on my development environment in SP. Sometimes it happens, sometimes it doesn't - luckily nothing that breaks the game but are very annoying when it happens.

Known bugs:
1. **Binding a P2P tunnel causes client network exception**. Internally, the client keeps track of its own list of P2P tunnels, and when the server syncs a new list, if the size of the list does not match, you get a network exception. *I do not know when or why this happens in SP*. I can imagine it booting you off a server if multiple people are adding P2P tunnels to the same network while you are looking in the GUI and binding.
2. Sometimes renaming the P2P tunnel does not persist across world save/load (This is probably AE2? I've confirmed that the P2P tunnel is renamed on the server side - at least the C2S packet is received, and we get an affirmative S2C packet from the server)
3. Binding a P2P tunnel causes the in-world highlight overlay to not properly display. For now, the workaround is to exit and re-enter the GUI.

If someone could help me pinpoint/confirm these bugs, that'll be great. I'm thinking of rewriting a not-insignificant portion of this code to safeguard against (1). (2) I would need help finding. (3) is minor. I know the cause and I can fix it (probably later today).