### PR TITLE
Fix P2P interface voiding/not saving settings on Adv. Mem. Card rebind

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    compile 'com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-104-GTNH:dev'
+    compile 'com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-160-GTNH:dev'
     compile 'com.github.GTNewHorizons:Forgelin:1.9.2-GTNH-1.7.10-Edition'
     compile 'com.github.GTNewHorizons:BuildCraft:7.1.27:dev'
 }


### PR DESCRIPTION
See commits for full description, but basically on rebind it created a new P2P interface instance without migrating settings over. Commit fixes this by defining what happens when the advanced memory card is used to rebind P2P interfaces

Note that the normal memory card doesn't have this behavior yet.

See https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11983