### PR TITLE
Fix client accessing the server world when it shouldn't

### DIFF
--- a/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
+++ b/src/main/java/com/projecturanus/betterp2p/client/gui/GuiAdvancedMemoryCard.kt
@@ -238,7 +238,11 @@ class GuiAdvancedMemoryCard(msg: S2CListP2P) : GuiScreen(), TextureBound {
             ClientCache.selectedFacing = selectedInfo?.facing
         }
         ClientCache.positions.clear()
-        ClientCache.positions.addAll(infos.sorted.filter { it.frequency == selectedInfo?.frequency && it != selectedInfo }.map { arrayListOf(it.posX, it.posY, it.posZ) to it.facing })
+        ClientCache.positions.addAll(infos.sorted.filter {
+            it.frequency == selectedInfo?.frequency &&
+            it != selectedInfo &&
+            it.dim == mc.thePlayer.dimension
+        }.map { arrayListOf(it.posX, it.posY, it.posZ) to it.facing })
     }
 
     override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int) {

--- a/src/main/java/com/projecturanus/betterp2p/network/P2PInfo.kt
+++ b/src/main/java/com/projecturanus/betterp2p/network/P2PInfo.kt
@@ -1,6 +1,7 @@
 package com.projecturanus.betterp2p.network
 
 import com.projecturanus.betterp2p.client.gui.InfoWrapper
+import net.minecraft.item.ItemStack
 import net.minecraftforge.common.util.ForgeDirection
 
 class P2PInfo(val frequency: Long,
@@ -11,7 +12,9 @@ class P2PInfo(val frequency: Long,
               val facing: ForgeDirection,
               val name: String,
               val output: Boolean,
-              val hasChannel: Boolean) {
+              val hasChannel: Boolean,
+              val channels: Int, //# of channels if ME P2P, or -1 else
+              val stack: ItemStack) {
 
     override fun hashCode(): Int {
         return hashP2P(posX, posY, posZ, facing.ordinal, world).hashCode()

--- a/src/main/java/com/projecturanus/betterp2p/network/S2CRefreshInfo.kt
+++ b/src/main/java/com/projecturanus/betterp2p/network/S2CRefreshInfo.kt
@@ -2,6 +2,8 @@ package com.projecturanus.betterp2p.network
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage
 import io.netty.buffer.ByteBuf
+import net.minecraft.item.ItemStack
+import net.minecraft.nbt.NBTTagCompound
 import net.minecraftforge.common.util.ForgeDirection
 
 fun readInfo(buf: ByteBuf): P2PInfo {
@@ -16,7 +18,15 @@ fun readInfo(buf: ByteBuf): P2PInfo {
     for (i in 0..nameLength) {
         name += buf.readChar()
     }
-    return P2PInfo(freq, posX, posY, posZ,world, facing, name, buf.readBoolean(), buf.readBoolean())
+    val output = buf.readBoolean()
+    val hasChannel = buf.readBoolean()
+    val channels = buf.readInt()
+    val compound = NBTTagCompound()
+    compound.setShort("id", buf.readShort())
+    compound.setShort("Damage", buf.readShort())
+    compound.setShort("Count", 1)
+    val stack = ItemStack.loadItemStackFromNBT(compound);
+    return P2PInfo(freq, posX, posY, posZ,world, facing, name, output, hasChannel, channels, stack)
 }
 
 fun writeInfo(buf: ByteBuf, info: P2PInfo) {
@@ -32,6 +42,11 @@ fun writeInfo(buf: ByteBuf, info: P2PInfo) {
     }
     buf.writeBoolean(info.output)
     buf.writeBoolean(info.hasChannel)
+    buf.writeInt(info.channels)
+    val compound = NBTTagCompound()
+    info.stack.writeToNBT(compound)
+    buf.writeShort(compound.getShort("id").toInt())
+    buf.writeShort(compound.getShort("Damage").toInt())
 }
 
 class S2CRefreshInfo(var infos: List<P2PInfo> = emptyList()) : IMessage {

--- a/src/main/java/com/projecturanus/betterp2p/util/p2p/P2PUtil.kt
+++ b/src/main/java/com/projecturanus/betterp2p/util/p2p/P2PUtil.kt
@@ -7,6 +7,7 @@ import appeng.api.parts.IPart
 import appeng.api.parts.PartItemStack
 import appeng.helpers.DualityInterface
 import appeng.me.GridAccessException
+import appeng.me.GridNode
 import appeng.parts.automation.UpgradeInventory
 import appeng.parts.p2p.PartP2PInterface
 import appeng.parts.p2p.PartP2PTunnel
@@ -143,4 +144,6 @@ val PartP2PTunnel<*>.hasChannel
     get() = isPowered && isActive
 
 fun PartP2PTunnel<*>.toInfo()
-    = P2PInfo(frequency, location.x, location.y, location.z, location.dimension, side, customName, isOutput, hasChannel)
+    = P2PInfo(frequency, location.x, location.y, location.z, location.dimension, side,
+              customName, isOutput, hasChannel, (externalFacingNode as? GridNode)?.usedChannels() ?: -1,
+              getItemStack(PartItemStack.Wrench))


### PR DESCRIPTION
Instead, the server now sends a packet with that information

In addition, fix P2P outlines being displayed when the player isn't in the same dimension

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13064