### PR TITLE
Fix issues when changing p2p type that involves conversion

### DIFF
--- a/src/main/java/com/projecturanus/betterp2p/network/data/GridServerCache.kt
+++ b/src/main/java/com/projecturanus/betterp2p/network/data/GridServerCache.kt
@@ -223,7 +223,7 @@ class GridServerCache(private val grid: IGrid, val player: EntityPlayer, var typ
         }
         var converted = false
         // Change to a static P2P type
-        if (newType.clazz.superclass == PartP2PTunnelStatic::class.java) {
+        if (PartP2PTunnelStatic::class.java.isAssignableFrom(newType.clazz)) {
             for ((i, stack) in player.inventory.mainInventory.withIndex()) {
                 if (stack?.isItemEqual(newType.stack) == true) {
                     player.inventory.decrStackSize(i, 1)

--- a/src/main/java/com/projecturanus/betterp2p/network/data/GridServerCache.kt
+++ b/src/main/java/com/projecturanus/betterp2p/network/data/GridServerCache.kt
@@ -10,6 +10,7 @@ import appeng.me.GridAccessException
 import appeng.me.cache.P2PCache
 import appeng.parts.automation.UpgradeInventory
 import appeng.parts.p2p.PartP2PTunnel
+import appeng.parts.p2p.PartP2PTunnelNormal
 import appeng.parts.p2p.PartP2PTunnelStatic
 import appeng.tile.inventory.AppEngInternalInventory
 import appeng.util.Platform
@@ -22,6 +23,7 @@ import net.minecraft.item.ItemStack
 import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.ChatComponentTranslation
 import net.minecraftforge.common.util.ForgeDirection
+import java.util.stream.Collectors
 
 /**
  * When the player uses the adv memory card, this is cached on the server side
@@ -219,30 +221,53 @@ class GridServerCache(private val grid: IGrid, val player: EntityPlayer, var typ
             player.addChatMessage(ChatComponentTranslation("gui.advanced_memory_card.error.same_type"))
             return null
         }
-        // Change to a static P2P type = require p2p in inventory
+        var converted = false
+        // Change to a static P2P type
         if (newType.clazz.superclass == PartP2PTunnelStatic::class.java) {
-            var canConvert = false
             for ((i, stack) in player.inventory.mainInventory.withIndex()) {
                 if (stack?.isItemEqual(newType.stack) == true) {
                     player.inventory.decrStackSize(i, 1)
-                    canConvert = true
+                    converted = true
                     break
                 }
             }
-            if (!canConvert) {
+            if (!converted) {
                 player.addChatMessage(ChatComponentTranslation("gui.advanced_memory_card.error.missing_items", 1, newType.stack.displayName))
                 return null
             }
         }
-        // Change from a static P2P type = give p2p back to the player
+        // Change from a static P2P type
         if (tunnel is PartP2PTunnelStatic<*>) {
+            val attunables = BetterP2P.proxy.getP2PTypeList().stream()
+                .filter{e -> PartP2PTunnelNormal::class.java.isAssignableFrom(e.clazz)}
+                // move exact type to the front so we check for it first
+                .sorted { o1, o2 -> if(o1.equals(newType)) -1 else if(o2.equals(newType)) 1 else 0 }
+                .collect(Collectors.toList())
+            outer@ for (attunable in attunables) {
+                for ((i, stack) in player.inventory.mainInventory.withIndex()) {
+                    if (stack?.isItemEqual(attunable.stack) == true) {
+                        player.inventory.decrStackSize(i, 1)
+                        converted = true
+                        break@outer
+                    }
+                }
+            }
+            if (!converted) {
+                player.addChatMessage(ChatComponentTranslation("gui.advanced_memory_card.error.missing_items", 1, newType.stack.displayName))
+                return null
+            }
+        }
+
+        // handle drops
+        if (converted) {
             val drop = ItemStack.copyItemStack(tunnel.itemStack)
             drop.stackSize = 1
-            if (!player.inventory.addItemStackToInventory(drop)) {
-                val drops = mutableListOf<ItemStack>(drop)
-                tunnel.getDrops(drops, false)
-                Platform.spawnDrops(player.worldObj, player.serverPosX, player.serverPosY, player.serverPosZ, drops)
+            val drops = mutableListOf<ItemStack>(drop)
+            tunnel.getDrops(drops, false)
+            for (j in drops) {
+                player.inventory.addItemStackToInventory(j)
             }
+            Platform.spawnDrops(player.worldObj, player.posX.toInt(), player.posY.toInt(), player.posZ.toInt(), drops)
         }
 
         val host = tunnel.host


### PR DESCRIPTION
Fix conversion to p2p-static doesn't return replaced p2p to inventory

Fix conversion to p2p-normal doesn't consume p2p from inventory

Fix drops in p2p are only dropped when no space in player inventory

Fix drops are dropped on player.serverPos which is not available on server side